### PR TITLE
feat: adjust starter-card styles with logo shrinks

### DIFF
--- a/card/src/Card.vue
+++ b/card/src/Card.vue
@@ -1,33 +1,47 @@
 <template>
   <!-- in case you don't want a clickable anchor card, simply don't pass a url and it will be a div instead -->
-  <component class="card" :is="url ? 'a' : 'div'" :href="url" v-on:click="(event) => $emit('click', event)" :class="{
+  <component
+    class="card"
+    :is="url ? 'a' : 'div'"
+    :href="url"
+    v-on:click="(event) => $emit('click', event)"
+    :class="{
       'starter-kit': true,
       'reduced-hover': reducedHover,
-    }" :style="
+    }"
+    :style="
       highlighted
         ? `background-color: ${backgroundColor};`
         : `background-color: black; border: 3px solid ${backgroundColor};`
-    ">
+    "
+  >
     <slot></slot>
     <div class="action-description details flex items-center">
-      {{ actionDescription }}
-      <svg xmlns="http://www.w3.org/2000/svg" style="
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        style="
           width: 1.5em;
           height: 1.5em;
           vertical-align: middle;
           top: 0.1em;
           position: relative;
           display: inline-block;
-        " aria-hidden="true" viewBox="0 0 20 20" fill="currentColor">
-        <path fill-rule="evenodd"
+        "
+        aria-hidden="true"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+      >
+        <path
+          fill-rule="evenodd"
           d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-          clip-rule="evenodd" />
+          clip-rule="evenodd"
+        />
       </svg>
     </div>
   </component>
 </template>
 <script>
-  export default {
+export default {
   props: {
     url: { type: String },
     onClick: { type: Object },
@@ -39,69 +53,64 @@
 };
 </script>
 <style lang="scss" scoped>
-  .starter-kit {
-    color: white;
-    text-decoration: inherit;
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    padding: 1em 1.2em;
-    border-radius: 0.75em;
-    overflow: hidden;
-    text-align: left;
+.starter-kit {
+  color: white;
+  text-decoration: inherit;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 1em 1.2em;
+  border-radius: 0.75em;
+  overflow: hidden;
+  text-align: left;
 
-    transition: all 0.4s ease;
+  transition: all 0.4s ease;
 
+  &:hover {
+    transform: scale(1.2);
+    filter: drop-shadow(0.2rem 0.2rem 0.25rem rgba(0, 0, 30, 0.5));
+  }
+
+  width: 18em;
+  height: 26em;
+}
+
+.starter-kit.reduced-hover:hover {
+  transform: scale(1.02);
+}
+
+.action-description {
+  font-size: 1em;
+  font-weight: bold;
+  position: absolute;
+  right: 0.5em;
+  bottom: 1em;
+  max-width: 50%;
+}
+
+.details {
+  overflow: hidden;
+  max-height: 0px;
+  opacity: 0;
+  transition: all 0.4s ease;
+}
+
+.card {
+  @mixin detailed-card {
+    .details {
+      max-height: 100%;
+      opacity: 1;
+    }
+  }
+
+  @media (hover: hover) {
     &:hover {
-      transform: scale(1.2);
-      filter: drop-shadow(0.2rem 0.2rem 0.25rem rgba(0, 0, 30, 0.5));
-    }
-
-    @media (min-width: 640px) {
-      width: 18em;
-      height: 26em;
-    }
-
-    width: 16em;
-    height: 24em;
-  }
-
-  .starter-kit.reduced-hover:hover {
-    transform: scale(1.02);
-  }
-
-  .action-description {
-    font-size: 1.0em;
-    font-weight: bold;
-    position: absolute;
-    right: 0.5em;
-    bottom: 1em;
-    max-width: 50%;
-  }
-
-  .details {
-    overflow: hidden;
-    max-height: 0px;
-    opacity: 0;
-    transition: all 0.4s ease;
-  }
-
-  .card {
-    @mixin detailed-card {
-      .details {
-        max-height: 100%;
-        opacity: 1;
-      }
-    }
-
-    @media (hover: hover) {
-      &:hover {
-        @include detailed-card;
-      }
-    }
-
-    @media (hover: none) {
       @include detailed-card;
     }
   }
+
+  @media (hover: none) {
+    @include detailed-card;
+  }
+}
 </style>

--- a/config/src/plans.js
+++ b/config/src/plans.js
@@ -117,7 +117,6 @@ export const Free = {
 
 export const Pro = {
   title: 'Pro',
-  banner: 'Free until september 2021',
   price: {
     value: '29',
     symbol: '$',

--- a/starter-card/src/StarterCard.vue
+++ b/starter-card/src/StarterCard.vue
@@ -1,11 +1,17 @@
 <template>
-  <component :is="Card" :url="url" @click="(event) => $emit('click', event)" :backgroundColor="backgroundColor"
-    class="card" :highlighted="highlighted">
+  <component
+    :is="Card"
+    :url="url"
+    @click="(event) => $emit('click', event)"
+    :backgroundColor="backgroundColor"
+    :highlighted="highlighted"
+    :class="{ card: true, 'a-highlighted': highlighted }"
+  >
     <div v-if="wip" class="wip-ribbon"><span>in progress...</span></div>
-    <div :class="{ logo: true, 'logo-highlighted': highlighted }">
+    <div :class="{ logo: true }">
       <img :src="heroImg" />
     </div>
-    <div :class="{ details: highlighted }" style="align-self: stretch; display: flex; flex-grow: 100">
+    <div :class="{ details: highlighted }">
       <p class="description">
         <slot></slot>
       </p>
@@ -25,18 +31,22 @@
       </span>
     </div>
     <img v-if="highlighted" class="framework-bg" :src="bgImg" />
-    <div v-else class="framework-bg" :style="`
+    <div
+      v-else
+      class="framework-bg"
+      :style="`
         -webkit-mask-image: url(${bgImg});
         -webkit-mask-position: center;
         -webkit-mask-repeat: no-repeat;
         mask-image: url(${bgImg});
         mask-position: center;
         mask-repeat: no-repeat;
-        background-color: ${backgroundColor}`" />
+        background-color: ${backgroundColor}`"
+    />
   </component>
 </template>
 <script>
-  import Card from '../../card/src/Card.vue';
+import Card from '../../card/src/Card.vue';
 
 export default {
   props: {
@@ -55,152 +65,161 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
+.card {
+  justify-content: space-between;
+}
+
+.logo {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    max-height: min(100%, 150px);
+    max-width: 100%;
+    transition: all 0.4s ease;
+    padding: 0 10px;
+    padding-top: 1em;
+  }
+}
+
+.a-highlighted {
   .logo {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-
-    img {
-      transition: all 0.4s ease;
-      max-width: 80%;
-      max-height: 100%;
-      width: auto;
-      height: 6em;
-      padding-top: 1em;
-    }
-  }
-
-  .logo-highlighted {
+    flex-shrink: 1;
     flex-grow: 1;
-
-    img {
-      max-width: 85%;
-      height: 15em;
-      padding-top: 0;
-    }
-  }
-
-  .wip-ribbon {
-    position: absolute;
-    right: -5px;
-    top: -5px;
+    min-height: 0;
+    min-width: 0;
     overflow: hidden;
-    width: 7.5em;
-    height: 7em;
-    text-align: right;
   }
 
-  .wip-ribbon span {
-    color: #000;
-    text-align: center;
-    line-height: 28px;
-    transform: rotate(40deg);
-    width: 10em;
-    display: block;
-    background: #fff;
-    box-shadow: 0 3px 10px -5px black;
-    position: absolute;
-    top: 1.8em;
-    right: -1.9em;
-    padding-left: 0.5em;
+  img {
+    padding-top: 0;
   }
+}
 
-  .description {
-    height: 100%;
-    display: flex;
-    align-items: center;
-    @media (hover: none) {
-      font-size: 0.9em;
+.wip-ribbon {
+  position: absolute;
+  right: -5px;
+  top: -5px;
+  overflow: hidden;
+  width: 7.5em;
+  height: 7em;
+  text-align: right;
+}
+
+.wip-ribbon span {
+  color: #000;
+  text-align: center;
+  line-height: 28px;
+  transform: rotate(40deg);
+  width: 10em;
+  display: block;
+  background: #fff;
+  box-shadow: 0 3px 10px -5px black;
+  position: absolute;
+  top: 1.8em;
+  right: -1.9em;
+  padding-left: 0.5em;
+}
+
+.description {
+  font-size: 0.9em;
+  display: flex;
+  align-items: center;
+}
+
+.framework-bg {
+  position: absolute;
+  width: 10rem;
+  height: 10rem;
+  right: 0;
+  bottom: 0;
+  opacity: 0.25;
+  transform: translateX(2rem) translateY(2rem) rotate(-12deg);
+  transition: all 0.4s ease;
+}
+
+p {
+  margin: 0;
+}
+
+.details {
+  @media (hover: none) {
+    font-size: 0.9em;
+  }
+  flex-grow: 1;
+  display: flex;
+  overflow: hidden;
+  max-height: 0px;
+  opacity: 0;
+  flex-shrink: 0;
+  transition: all 0.4s ease;
+  margin-bottom: 1em;
+  margin-top: 1em;
+}
+
+.card {
+  @mixin detailed-card {
+    .framework-bg {
+      opacity: 0.2;
+    }
+
+    .details {
+      max-height: 15em;
+      opacity: 1;
+    }
+
+    .logo {
+      img {
+        max-width: 85%;
+      }
     }
   }
 
-  .framework-bg {
-    position: absolute;
-    width: 10rem;
-    height: 10rem;
-    right: 0;
-    bottom: 0;
-    opacity: 0.25;
-    transform: translateX(2rem) translateY(2rem) rotate(-12deg);
-    transition: all 0.4s ease;
-  }
-
-  p {
-    margin: 0;
-  }
-
-  .details {
-    overflow: hidden;
-    max-height: 0px;
-    opacity: 0;
-    transition: all 0.4s ease;
-  }
-
-  .card {
-    @mixin detailed-card {
-      .framework-bg {
-        opacity: 0.2;
-      }
-
-      .details {
-        max-height: 100%;
-        opacity: 1;
-      }
-
-      .logo-highlighted {
-        img {
-          height: 5rem;
-          padding-top: 1em;
-        }
-      }
-    }
-
-    @media (hover: hover) {
-      &:hover {
-        @include detailed-card;
-      }
-    }
-
-    @media (hover: none) {
+  @media (hover: hover) {
+    &:hover {
       @include detailed-card;
     }
   }
 
-  .powered-by,
-  .owner {
-    font-size: 0.9em;
+  @media (hover: none) {
+    @include detailed-card;
+  }
+}
+
+.powered-by,
+.owner {
+  font-size: 0.9em;
+  @media (hover: none) {
+    font-size: 0.8em;
+  }
+
+  :first-child {
+    font-size: 0.8em;
+  }
+
+  span {
+    display: block;
+  }
+
+  img {
+    transition: opacity 0.4s ease;
+    height: 1.5em;
+    width: 1.5em;
     @media (hover: none) {
-      font-size: 0.8em;
+      height: 1.2em;
+      width: 1.2em;
     }
-
-    :first-child {
-      font-size: 0.8em;
-    }
-
-    span {
-      display: block;
-    }
-
-    img {
-      transition: opacity 0.4s ease;
-      height: 1.5em;
-      width: 1.5em;
-      @media (hover: none) {
-        height: 1.2em;
-        width: 1.2em;
-      }
-      display: inline-block;
-      vertical-align: middle;
-      margin-right: 0.2em;
-      top: -0.15em;
-      position: relative;
-    }
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: 0.2em;
+    top: -0.15em;
+    position: relative;
   }
+}
 
-  .powered-by {
-    margin-top: auto;
-    margin-bottom: 0.4em;
-  }
+.powered-by {
+  margin-bottom: 0.4em;
+}
 </style>

--- a/starter-card/stories/index.stories.tsx
+++ b/starter-card/stories/index.stories.tsx
@@ -38,7 +38,7 @@ export const highlighted = (args) => ({
       backgroundColor: '#30c6b9',
       heroImg: 'https://backlight.dev/assets/lib-white/chakra-typo.svg',
       name: 'Chakra',
-      desc: `Chakra UI is a simple, modular and accessible component library. 
+      desc: `Chakra UI is a simple, modular and accessible component library.
     Based on system-ui tokens.`,
       url: '/edit/sNbJipmRTmslL3f8RZaO',
       bgImg: 'https://backlight.dev/assets/lib-white/react.svg',
@@ -50,6 +50,55 @@ export const highlighted = (args) => ({
         ['fmk2', 'https://backlight.dev/assets/lib-white/sass.svg'],
       ]),
       wip: true,
+    },
+  }),
+  ...args,
+});
+
+export const smallContent = (args) => ({
+  setup: () => ({
+    props: {
+      backgroundColor: '#967a2d',
+      heroImg: 'https://backlight.dev/assets/lib-white/simba.svg',
+      desc: `<ul class="list-disc list-inside">
+        <li>Open-source</li>
+        <li>20+ Web Components already</li>
+        <li>Based on Lion's accessible components</li>
+        <li>Dark mode out-of-the-box</li>
+        </ul>`,
+      url: '/edit/5vtJtbY04aoD1dGKcsu1',
+      bgImg: 'https://backlight.dev/assets/lib-white/lit.svg',
+      owner: 'divriots',
+      ownerPhoto: 'https://backlight.dev/assets/logo/dr-b.svg',
+      highlighted: true,
+      frameworks: new Map([
+        ['Lion', 'https://backlight.dev/assets/lib-white/lion.svg'],
+        ['Lit', 'https://backlight.dev/assets/lib-white/lit.svg'],
+      ]),
+    },
+  }),
+  ...args,
+});
+
+export const largeContent = (args) => ({
+  setup: () => ({
+    props: {
+      backgroundColor: 'rgb(98, 0, 238)',
+      heroImg: 'https://backlight.dev/assets/lib-white/smelte.svg',
+      desc: `<ul><li>Mobile &amp; Web</li><li>Based on Paper components</li><li>Paper Design Token</li><li>25+ cross-platform components</li><li>Dark mode support</li></ul><ul><li>Mobile &amp; Web</li><li>Based on Paper components</li><li>Paper Design Token</li><li>25+ cross-platform components</li><li>Dark mode support</li></ul>`,
+      url: '/edit/5vtJtbY04aoD1dGKcsu1',
+      bgImg: 'https://backlight.dev/assets/lib-white/lit.svg',
+      owner: 'divriots',
+      ownerPhoto: 'https://backlight.dev/assets/logo/dr-b.svg',
+      highlighted: true,
+      frameworks: new Map([
+        ['Paper', 'https://backlight.dev/assets/lib-white/paper.svg'],
+        [
+          'React-Native',
+          'https://backlight.dev/assets/lib-white/react-native.svg',
+        ],
+        ['Something cool', ''],
+      ]),
     },
   }),
   ...args,


### PR DESCRIPTION
https://backlight.dev/preview/1SuMaEt5uxgp62VC8WVP/starter-card?branch=~starter-logos@RWNyOkzvYQfzocx91XjHjbDB27o1

- Changed description font-size to 14px
- Removed Free until september banner
- Removed "Get started" from action description so it's just the arrow now
- Adjusted size for mobile, it's the same as on desktop now because 1 card fits just fine on mobile
- Rewrote most of the flexbox CSS for the cards so that the image takes up the proper space, and shrinks so that the description can fit