### PR TITLE
Feature/mobile adjustments

### DIFF
--- a/doubt-removers/src/index.tsx
+++ b/doubt-removers/src/index.tsx
@@ -3,7 +3,7 @@ import content from './content';
 
 function DoubtRemovers() {
   return (
-    <section className="bg-black-divriots text-white px-8 py-12 -my-2 ">
+    <section className="bg-black-divriots text-white px-8 py-12 -my-2 overflow-hidden">
       <article className="md:px-20">
         <h3
           data-aos="fade-left"

--- a/doubt-removers/src/index.tsx
+++ b/doubt-removers/src/index.tsx
@@ -3,8 +3,8 @@ import content from './content';
 
 function DoubtRemovers() {
   return (
-    <section className="bg-black-divriots text-white px-8 py-12 -my-2 overflow-hidden">
-      <article className="md:px-20">
+    <section className="bg-black-divriots text-white px-8 py-12 -my-2">
+      <article className="md:px-20 overflow-hidden">
         <h3
           data-aos="fade-left"
           className="main-title text-center my-10 sm:my-20"


### PR DESCRIPTION
The horizontal animation of the title was causing an overflow in its initial state. With the overflow hidden the component crops the content overflowing its size and avoiding the horizontal scroll.