### PR TITLE
Feature/menu active mobile

### DIFF
--- a/navbar/stories/navbar.stories.ts
+++ b/navbar/stories/navbar.stories.ts
@@ -13,19 +13,19 @@ export const navbar = () => ({
     return {
       routes: [
         {
-          pathname: '#',
+          pathname: '/princing',
           label: 'Pricing',
         },
         {
-          pathname: '#',
+          pathname: '/get-started',
           label: 'Get started',
         },
         {
-          pathname: '#',
+          pathname: '/blog',
           label: 'Blog',
         },
       ],
-      pathname: '/blog',
+      pathname: '/get-started',
     };
   },
   template: `<NavBar :routes="routes" :pathname="pathname" :appRoute="appRoute"/>`,

--- a/navmenu-item/src/navmenu-item.vue
+++ b/navmenu-item/src/navmenu-item.vue
@@ -2,13 +2,13 @@
   <a :href="route.pathname" :class="`
       text-inherit
       ml-2
-      pb-1
-      border-0 border-b-4 border-solid border-transparent
       ${isMobile ? 'px-2 py-1 block' : 'px-3'}
       ${isActive ? 'active' : ''}
       nav-link
     `">
-    {{ route.label }}
+    <span :class="`inline-block pb-1 border-0 border-b-4 border-solid border-transparent`">
+      {{ route.label }}
+    </span>
   </a>
 </template>
 <script>

--- a/navmenu-item/src/navmenu-item.vue
+++ b/navmenu-item/src/navmenu-item.vue
@@ -6,7 +6,7 @@
       ${isActive ? 'active' : ''}
       nav-link
     `">
-    <span :class="`inline-block pb-1 border-0 border-b-4 border-solid border-transparent`">
+    <span class="inline-block pb-1 border-0 border-b-4 border-solid border-transparent">
       {{ route.label }}
     </span>
   </a>

--- a/tailwind/src/commons.css
+++ b/tailwind/src/commons.css
@@ -2,7 +2,7 @@
 @tailwind utilities;
 
 @layer components {
-  .nav-link:hover,
+  .nav-link:hover span,
   .nav-link.active span {
     @apply border-primary;
   }

--- a/tailwind/src/commons.css
+++ b/tailwind/src/commons.css
@@ -3,7 +3,7 @@
 
 @layer components {
   .nav-link:hover,
-  .nav-link.active {
+  .nav-link.active span {
     @apply border-primary;
   }
   .scrollable-horizontal {


### PR DESCRIPTION
This branch adds a `<span>` inside the `<a>` element to handle the bottom border while keeping the link as a block. The `navbar` organism story is also fixed.

For backlight landing and docs we should make sure it works fine. There's a patch on a vitepress shared layout to handle the menu active option (but `navbar` component already does this if the `pathname` prop is correctly passed). That patch is here:

https://github.com/divriots/webcomponents-editor/blob/master/shared/_vitepress/theme/components/DocLayout.vue#L114

I believe after @m4dz changes from yesterday, that line is not rendering anymore on the landing, not sure why, but would be great if you can test this branch of lcd win all vitepress sites using that DocLayout component.

In case that css still applies and is not working properly we have two possible solutions:

1. Fixing the selector adding a span

```
      <span
        v-html="
          `<style>.nav-bar a.nav-link[href^='${base}'] span{border-color:var(--c-brand);}</style>`
        "
      ></span>
```

2. Passing correctly the `pathname` prop so `navbar` handles the active state.