### PR TITLE
fix: revert reversion, fix arrow z-index, pad 1 card-width at a time

### DIFF
--- a/highlight/src/Highlight.vue
+++ b/highlight/src/Highlight.vue
@@ -241,6 +241,7 @@
 
   .right-paddle {
     right: 10px;
+    z-index: 5;
   }
 </style>
 
@@ -248,37 +249,14 @@
   import StarterCard from '../../starter-card/src/StarterCard.vue';
 import Card from '../../card/src/Card.vue';
 import kits from './data';
-import setupScrollArrows from './scroll-arrows.js';
-
-let target;
-
-function dragHandler() {
-  if (!target.dragging) {
-    return;
-  }
-  target.scrollLeft -= (target.xDiff ?? 0) * 4;
-  target.xDiff = 0;
-  requestAnimationFrame(dragHandler);
-}
-
-function mouseUpHandler() {
-  target.dragging = false;
-}
-
-function mouseDownHandler(ev) {
-  ev.preventDefault();
-  target.oldMousePosX = ev.clientX;
-  target.dragging = true;
-  dragHandler();
-}
-
-function mouseMoveHandler(ev) {
-  if (!target.dragging) {
-    return;
-  }
-  target.xDiff = ev.clientX - target.oldMousePosX;
-  target.oldMousePosX = ev.clientX;
-}
+import { 
+  setupScrollArrows, 
+  teardownScrollArrows,
+} from './scroll-arrows.js';
+import {
+  setupDragHandling, 
+  teardownDragHandling, 
+} from './drag-handling.js';
 
 export default {
   computed: {
@@ -292,16 +270,12 @@ export default {
   mounted: function () {
     this.$nextTick(function () {
       setupScrollArrows();
-      target = document.querySelector('.highlights-container');
-      target.addEventListener('mousedown', mouseDownHandler);
-      target.addEventListener('mousemove', mouseMoveHandler);
-      target.addEventListener('mouseup', mouseUpHandler);
+      setupDragHandling();
     });
   },
   beforeUnmount: function () {
-    target.removeEventListener('mousedown', mouseDownHandler);
-    target.addEventListener('mousemove', mouseMoveHandler);
-    target.removeEventListener('mouseup', mouseUpHandler);
+    teardownScrollArrows();
+    teardownDragHandling();
   },
 };
 </script>

--- a/highlight/src/drag-handling.js
+++ b/highlight/src/drag-handling.js
@@ -1,0 +1,65 @@
+let target;
+let anchors;
+
+function dragHandler() {
+  if (!target.dragging) {
+    return;
+  }
+  target.scrollLeft -= (target.xDiff ?? 0) * 4;
+  target.xDiff = 0;
+  requestAnimationFrame(dragHandler);
+}
+
+function mouseUpHandler() {
+  target.mouseDown = false;
+  // preventing the anchor default depends on dragging state,
+  // but mouseup is fired before click, so wait 1 render frame
+  // before setting it back to false
+  requestAnimationFrame(() => {
+    target.dragging = false;
+  });
+}
+
+function mouseDownHandler(ev) {
+  ev.preventDefault();
+  target.oldMousePosX = ev.clientX;
+  target.mouseDown = true;
+}
+
+function mouseMoveHandler(ev) {
+  if (target.mouseDown && !target.dragging) {
+    target.dragging = true;
+    dragHandler();
+  }
+  if (!target.dragging) {
+    return;
+  }
+  target.xDiff = ev.clientX - target.oldMousePosX;
+  target.oldMousePosX = ev.clientX;
+}
+
+function preventAnchorClickDuringDrag(ev) {
+  if (target.dragging) {
+    ev.preventDefault();
+  }
+}
+
+export function setupDragHandling() {
+  target = document.querySelector('.highlights-container');
+  target.addEventListener('mousedown', mouseDownHandler);
+  target.addEventListener('mousemove', mouseMoveHandler);
+  target.addEventListener('mouseup', mouseUpHandler);
+  anchors = Array.from(target.querySelectorAll('a'));
+  anchors.forEach((anchor) => {
+    anchor.addEventListener('click', preventAnchorClickDuringDrag);
+  });
+}
+
+export function teardownDragHandling() {
+  target.removeEventListener('mousedown', mouseDownHandler);
+  target.addEventListener('mousemove', mouseMoveHandler);
+  target.removeEventListener('mouseup', mouseUpHandler);
+  anchors.forEach((anchor) => {
+    anchor.removeEventListener('click', preventAnchorClickDuringDrag);
+  });
+}

--- a/highlight/src/scroll-arrows.js
+++ b/highlight/src/scroll-arrows.js
@@ -1,10 +1,13 @@
 let leftPaddle;
 let rightPaddle;
 let menuContainer;
+let menuFullSize;
+let menuItemWidth;
 // get some relevant size for the paddle triggering point
 const paddleMargin = 40;
 
-function handlePaddleButtons(menuFullSize, menuContainerSize) {
+function handlePaddleButtons() {
+  const menuContainerSize = menuContainer.getBoundingClientRect().width;
   const menuInvisibleSize = menuFullSize - menuContainerSize;
   const menuPosition = menuContainer.scrollLeft;
   const menuStartOffset = paddleMargin;
@@ -23,46 +26,41 @@ function handlePaddleButtons(menuFullSize, menuContainerSize) {
   }
 }
 
-function setupListeners(menuFullSize) {
-  window.addEventListener('resize', () => {
-    handlePaddleButtons(
-      menuFullSize,
-      menuContainer.getBoundingClientRect().width
-    );
-  });
-
-  menuContainer.addEventListener('scroll', () => {
-    handlePaddleButtons(
-      menuFullSize,
-      menuContainer.getBoundingClientRect().width
-    );
-  });
-
-  rightPaddle.addEventListener('click', function () {
-    menuContainer.scrollTo({
-      left: menuFullSize,
-      behavior: 'smooth',
-    });
-  });
-
-  leftPaddle.addEventListener('click', function () {
-    menuContainer.scrollTo({
-      left: 0,
-      behavior: 'smooth',
-    });
+function padRightHandler() {
+  menuContainer.scrollTo({
+    left: menuContainer.scrollLeft + menuItemWidth,
+    behavior: 'smooth',
   });
 }
 
-export default function setupScrollArrows() {
+function padLeftHandler() {
+  menuContainer.scrollTo({
+    left: menuContainer.scrollLeft - menuItemWidth,
+    behavior: 'smooth',
+  });
+}
+
+function setupListeners() {
+  window.addEventListener('resize', handlePaddleButtons);
+  menuContainer.addEventListener('scroll', handlePaddleButtons);
+  rightPaddle.addEventListener('click', padRightHandler);
+  leftPaddle.addEventListener('click', padLeftHandler);
+}
+
+export function setupScrollArrows() {
   leftPaddle = document.querySelector('.left-paddle');
   rightPaddle = document.querySelector('.right-paddle');
   menuContainer = document.querySelector('.highlights-container');
-  const menuFullSize = menuContainer.scrollWidth;
+  menuFullSize = menuContainer.scrollWidth;
+  menuItemWidth = menuFullSize / menuContainer.childElementCount;
 
-  setupListeners(menuFullSize);
+  setupListeners();
+  handlePaddleButtons();
+}
 
-  handlePaddleButtons(
-    menuFullSize,
-    menuContainer.getBoundingClientRect().width
-  );
+export function teardownScrollArrows() {
+  window.removeEventListener('resize', handlePaddleButtons);
+  menuContainer.removeEventListener('scroll', handlePaddleButtons);
+  rightPaddle.removeEventListener('click', padRightHandler);
+  leftPaddle.removeEventListener('click', padLeftHandler);
 }


### PR DESCRIPTION
Something happened where my arrows for the highlight component were at an old version, either something was deleted or reverted. Dunno... but I still had the commit so I reverted the revert :D 

And added two improvements:
- right arrow was hidden by siblings because they use z-index to stack, so the arrow needs to stack over those
- pad buttons now pad max. 1 item per click, looks more slick :)

https://i.imgur.com/wD2pGUF.gif