### PR TITLE
fix: checkmarks aligned with perks

### DIFF
--- a/price-features/src/index.vue
+++ b/price-features/src/index.vue
@@ -1,6 +1,6 @@
 <template>
   <ul class="flex-grow border-t-2 border-b-2 border-gray-divriots py-8">
-    <li class="mb-4 flex items-start text-left" v-if="inherits">
+    <li class="mb-4 flex items-center text-left" v-if="inherits">
       <div class="flex-shrink-0">
         <svg
           class="h-6 w-6 text-teal-500"
@@ -19,7 +19,7 @@
       <p class="ml-3 text-base font-bold">All {{ inherits.title }} features</p>
     </li>
     <li
-      class="mb-4 flex items-start text-left"
+      class="mb-4 flex items-center text-left"
       v-for="feature of additionalFeatures"
       :key="feature.label"
     >


### PR DESCRIPTION
This was bothering me...

Before --------------------------------------------------- After
<div class="flex">
  <img src="https://user-images.githubusercontent.com/36734656/139893262-bc7d20f1-6e92-40e1-9154-0fbb4dd9e2b5.png">
  <img src="https://user-images.githubusercontent.com/36734656/139893497-325fb5e3-0e07-4d25-a598-31b5683c6bb4.png">
</div>