### PR TITLE
Push from fix-hover-hero-button

### DIFF
--- a/hero/src/index.vue
+++ b/hero/src/index.vue
@@ -186,7 +186,7 @@ export default {
             </svg>
           </button>
         </div>
-        <div class="set-height" v-show="playing">
+        <div class="set-size" v-show="playing">
           <div class="video-players rounded-lg relative mx-auto">
             <div
               v-if="isYoutube"
@@ -323,7 +323,7 @@ export default {
     opacity: 0;
   }
 }
-.set-height {
+.set-size {
   @media only screen and (min-width: 1024px) {
     min-height: 784px;
     display: flex;
@@ -355,7 +355,9 @@ export default {
     left: 55%;
   }
 }
-
+.primary-btn-fix:hover::before {
+  display: none;
+}
 .primary-btn-fix:hover {
   transform: translate(-50%, -50%) scale(1.2);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divriots/lcd",
-  "version": "0.2.9",
+  "version": "0.2.12",
   "license": "GPLV3",
   "scripts": {
     "serve": "npx backlight@latest serve 1SuMaEt5uxgp62VC8WVP --open"


### PR DESCRIPTION
Fix to the almost transparent square appearing behind the hero play button on hover.
![image](https://user-images.githubusercontent.com/62674145/154688772-9187133a-ac88-4bd9-8a42-2ba13f703626.png)
