### PR TITLE
fix: recompute menu item / container width on resize

### DIFF
--- a/highlight/src/scroll-arrows.js
+++ b/highlight/src/scroll-arrows.js
@@ -40,25 +40,30 @@ function padLeftHandler() {
   });
 }
 
+function computeMenuItemWidth() {
+  menuFullSize = menuContainer.scrollWidth;
+  menuItemWidth = menuFullSize / menuContainer.childElementCount;
+}
+
 function setupListeners() {
+  window.addEventListener('resize', computeMenuItemWidth);
   window.addEventListener('resize', handlePaddleButtons);
   menuContainer.addEventListener('scroll', handlePaddleButtons);
   rightPaddle.addEventListener('click', padRightHandler);
   leftPaddle.addEventListener('click', padLeftHandler);
 }
 
-export function setupScrollArrows( leftId, rightId, containerId) {
+export function setupScrollArrows(leftId, rightId, containerId) {
   leftPaddle = document.getElementById(leftId);
   rightPaddle = document.getElementById(rightId);
   menuContainer = document.getElementById(containerId);
-  menuFullSize = menuContainer.scrollWidth;
-  menuItemWidth = menuFullSize / menuContainer.childElementCount;
-
+  computeMenuItemWidth();
   setupListeners();
   handlePaddleButtons();
 }
 
 export function teardownScrollArrows() {
+  window.removeEventListener('resize', computeMenuItemWidth);
   window.removeEventListener('resize', handlePaddleButtons);
   menuContainer.removeEventListener('scroll', handlePaddleButtons);
   rightPaddle.removeEventListener('click', padRightHandler);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divriots/lcd",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "license": "GPLV3",
   "scripts": {
     "serve": "npx backlight@latest serve 1SuMaEt5uxgp62VC8WVP --open"


### PR DESCRIPTION
This should fix the testimonial section which uses these scroll arrows, but on resize the container of the testimonials and its items change a bit in size, so this PR will make the arrows navigate 1 card at a time properly when resizing viewport.