### PR TITLE
feat: make studio route configurable

### DIFF
--- a/navbar/src/navbar.vue
+++ b/navbar/src/navbar.vue
@@ -7,7 +7,7 @@
         <slot name="search" />
         <div class="hidden md:block md:ml-6">
           <div class="flex items-baseline justify-end">
-            <component :is="NavMenu" :pathname="pathname" :routes="routes"></component>
+            <component :is="NavMenu" :pathname="pathname" :routes="routes" :studioRoute="studioRoute"></component>
           </div>
         </div>
         <div class="inset-y-0 right-0 flex items-center md:hidden">
@@ -42,7 +42,7 @@
     <input class="hidden" type="checkbox" id="navexpander" checked />
     <div id="mobile-menu" class="md:hidden">
       <div class="px-2 pt-2 pb-3 space-y-1 text-left">
-        <component :is="NavMenu" :pathname="pathname" :routes="routes"></component>
+        <component :is="NavMenu" :pathname="pathname" :routes="routes" :studioRoute="studioRoute"></component>
       </div>
     </div>
   </nav>
@@ -60,6 +60,7 @@ export default {
   props: {
     routes: { type: Array, required: true },
     pathname: { type: String, default: '' },
+    studioRoute: { type: String, required: true },
   },
   setup() {
     return { Logo, NavMenu };

--- a/navbar/stories/navbar.stories.ts
+++ b/navbar/stories/navbar.stories.ts
@@ -26,7 +26,8 @@ export const navbar = () => ({
         },
       ],
       pathname: '/get-started',
+      studioRoute: 'https://studio.foobar',
     };
   },
-  template: `<NavBar :routes="routes" :pathname="pathname" :appRoute="appRoute"/>`,
+  template: `<NavBar :routes="routes" :pathname="pathname" :studioRoute="studioRoute"/>`,
 });

--- a/navmenu/src/navmenu.vue
+++ b/navmenu/src/navmenu.vue
@@ -7,7 +7,7 @@
     :isMobile="true"
     :isActive="current === route"
   ></component>
-  <a href="/studio" class="btn-outline ml-2 inline-block">Log in</a>
+  <a :href="studioRoute" class="btn-outline ml-2 inline-block">Log in</a>
 </template>
 <style scoped>
 #navexpander:checked ~ #mobile-menu {
@@ -19,6 +19,7 @@ import NavMenuItem from '../../navmenu-item/src/navmenu-item.vue';
 export default {
   props: {
     routes: { type: Array, required: true },
+    studioRoute: { type: String, required: true },
     pathname: { type: String, default: '' },
     isMobile: { type: Boolean, default: false },
   },

--- a/navmenu/stories/navmenu.stories.ts
+++ b/navmenu/stories/navmenu.stories.ts
@@ -22,7 +22,8 @@ export const nav_menu = () => ({
         },
       ],
       pathname: '/get-started/abc/',
+      studioRoute: 'https://studio.foobar',
     };
   },
-  template: `<NavMenu :routes="routes" :pathname="pathname" />`,
+  template: `<NavMenu :routes="routes" :pathname="pathname" :studioRoute="studioRoute"/>`,
 });


### PR DESCRIPTION
Instead of just using /studio as now we have a separate hosting
for it, might as well target it directly to avoid the vue router
redirects
